### PR TITLE
Readd restyled script

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -48,8 +48,7 @@ restylers:
     enabled: true
     image: restyled/restyler-dotnet-format:v0.0.1-2
     command:
-      - dotnet-format
-      - "--files"
+      - dotnet-format-files
       - "--folder ."
     arguments: []
     include:


### PR DESCRIPTION
Revert back to using 'dotnet-format-files' script to ensure '--files'
option preceeds file arguments.