### PR TITLE
Refactor some variable and event names

### DIFF
--- a/Editor/ISolutionSyncEvents.cs
+++ b/Editor/ISolutionSyncEvents.cs
@@ -15,7 +15,7 @@ namespace Mojur.Unity.SolutionProcessing
         /// <remarks>
         /// A completed status of true in <see cref="ISolutionSyncStatus"/> results in
         /// neither .csproj's nor .sln's being generated. Thus <see cref="SlnGenerated"/>
-        /// and <see cref="CSProjGenerated"/> events are not triggered.
+        /// and <see cref="CsprojGenerated"/> events are not triggered.
         /// </remarks>
         event Action<ISolutionSyncStatus> SolutionSyncing;
 
@@ -24,7 +24,7 @@ namespace Mojur.Unity.SolutionProcessing
         /// </summary>
         /// <remarks>
         /// Content of .sln file will be overwritten by the content of <see cref="IGeneratedFile"/>.
-        /// Triggered before <see cref="CSProjGenerated"/>.
+        /// Triggered before <see cref="CsprojGenerated"/>.
         /// </remarks>
         event Action<IGeneratedFile> SlnGenerated;
 
@@ -35,7 +35,7 @@ namespace Mojur.Unity.SolutionProcessing
         /// Content of .csproj file will be overwritten by the content of <see cref="IGeneratedFile"/>.
         /// Triggered after <see cref="SlnGenerated"/>.
         /// </remarks>
-        event Action<IGeneratedFile> CSProjGenerated;
+        event Action<IGeneratedFile> CsprojGenerated;
 
         /// <summary>
         /// Occurs when solution synchronization is complete (.csproj and .sln files).

--- a/Editor/Internal/ISolutionSyncProcessorRepository.cs
+++ b/Editor/Internal/ISolutionSyncProcessorRepository.cs
@@ -6,7 +6,7 @@ namespace Mojur.Unity.SolutionProcessing.Internal
 {
     /// <summary>
     /// Gathers <see cref="ISolutionSyncProcessor"/>s.
-    /// </summary>b
+    /// </summary>
     internal interface ISolutionSyncProcessorRepository
     {
         /// <summary>

--- a/Editor/Internal/Mojur.Unity.SolutionProcessing.Editor.Internal.asmdef
+++ b/Editor/Internal/Mojur.Unity.SolutionProcessing.Editor.Internal.asmdef
@@ -1,8 +1,7 @@
 {
     "name": "Mojur.Unity.SolutionProcessing.Editor.Internal",
     "references": [
-        "GUID:6384f42c860431c4194d410a07bf5d24",
-        "GUID:e13643193ffcac649b980bd9ed937d5c"
+        "GUID:6384f42c860431c4194d410a07bf5d24"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/Editor/Internal/SolutionProcessorPublisher.cs
+++ b/Editor/Internal/SolutionProcessorPublisher.cs
@@ -18,16 +18,16 @@ namespace Mojur.Unity.SolutionProcessing.Internal
         public event Action<IGeneratedFile> SlnGenerated;
 
         /// <inheritdoc />
-        public event Action<IGeneratedFile> CSProjGenerated;
+        public event Action<IGeneratedFile> CsprojGenerated;
 
         /// <inheritdoc />
         public event Action SolutionSynced;
 
-        public SolutionProcessorPublisher(IEnumerable<ISolutionSyncProcessor> listeners)
+        public SolutionProcessorPublisher(IEnumerable<ISolutionSyncProcessor> processors)
         {
-            foreach (var listener in listeners)
+            foreach (var processor in processors)
             {
-                listener.RegisterSubscriptions(this);
+                processor.RegisterSubscriptions(this);
             }
         }
 
@@ -41,19 +41,19 @@ namespace Mojur.Unity.SolutionProcessing.Internal
         }
 
         /// <inheritdoc />
-        public string PublishSlnGenerated(string path, string contents)
+        public string PublishSlnGenerated(string path, string content)
         {
-            var file = new GeneratedFile(new FileInfo(path), contents);
+            var file = new GeneratedFile(new FileInfo(path), content);
             this.SlnGenerated?.Invoke(file);
 
             return file.Content;
         }
 
         /// <inheritdoc />
-        public string PublishCsprojGenerated(string path, string contents)
+        public string PublishCsprojGenerated(string path, string content)
         {
-            var file = new GeneratedFile(new FileInfo(path), contents);
-            this.CSProjGenerated?.Invoke(file);
+            var file = new GeneratedFile(new FileInfo(path), content);
+            this.CsprojGenerated?.Invoke(file);
 
             return file.Content;
         }


### PR DESCRIPTION
- Renames `CSProj` to `Csproj` to better represent the file extension
- Fixes the legacy naming of `listeners`
- Removes unnecessary assembly reference